### PR TITLE
#162411163 add endpoint for fetching a single incident

### DIFF
--- a/app/api/v2/models/incidents_model.py
+++ b/app/api/v2/models/incidents_model.py
@@ -2,6 +2,7 @@ from db_config import db_connection
 from flask import jsonify
 import psycopg2
 import os
+types_of_statuses = ["under investigation", "rejected", "resolved", "draft"]
 
 
 class Incidents():
@@ -79,3 +80,37 @@ class Incidents():
                 "status": 200,
                 "data": incidents_list
             }, 200
+
+    def get_one_incident(self, type, incident_id):
+        """gets a single intervention record"""
+
+        query = self.incident_fetch()
+
+        conn = db_connection()
+        cur = conn.cursor()
+
+        cur.execute(query, (type, incident_id,))
+        intervention_data = cur.fetchone()
+
+        if intervention_data is None:
+            return {
+                "status": 404,
+                "message": "This " + type + " record does not exist"
+            }, 404
+
+        intervention_dict = {
+            "id": intervention_data[0],
+            "create_on": str(intervention_data[1]),
+            "create_by": str(intervention_data[2]),
+            "type": intervention_data[3],
+            "location": intervention_data[4],
+            "status": intervention_data[5],
+            "comment": intervention_data[6],
+            "images": intervention_data[7],
+            "video": intervention_data[8]
+        }
+
+        return {
+            "status": 200,
+            "data": intervention_dict
+        }

--- a/app/api/v2/routes2.py
+++ b/app/api/v2/routes2.py
@@ -13,3 +13,4 @@ api.add_resource(UsersView, 'auth/signup')
 api.add_resource(OneUser, 'auth/login')
 
 api.add_resource(IncidentViews, '<type>s')
+api.add_resource(OneIntervention, '<type>s/<incident_id>')

--- a/app/api/v2/views/incidents_view.py
+++ b/app/api/v2/views/incidents_view.py
@@ -75,7 +75,26 @@ class IncidentViews(Resource, Incidents):
         return self.incidents.save_incident(created_by, record_type, location,
                                             status, comment, images, video)
 
+    @jwt_required
     def get(self, type):
         """fetches a list of all the incident records by type"""
 
         return self.incidents.get_all_interventions(type)
+
+
+class OneIntervention(Resource, Incidents):
+    """class to hold methods for a single intervention records"""
+
+    def __init__(self):
+        self.incidents = Incidents()
+
+    def get(self, type, incident_id):
+        """gets a single intervention record by id"""
+
+        if incident_id.isdigit() is False:
+            return {
+                "status": 400,
+                'message': type + ' ID {} is invalid'.format(incident_id)
+                }, 400
+
+        return self.incidents.get_one_incident(type, incident_id)


### PR DESCRIPTION
#### What does this PR do?
Add the endpoint for fetching a single intervention record or red flag
#### Description of Task to be completed?
Create an endpoint for getting a single incident records based on the type.
#### How should this be manually tested?

- clone the repo
- git clone https://github.com/Benkimeric/iReporter-API.git
- create and activate the virtual environment
- virtualenv <environment name>
- $source <env name>/bin/activate (in bash)
- install project dependencies by:
    $pip install -r requirements.txt
- python  run.py or flask run
- Use postman to test the endpoint at this route `api/v2/<type>s/`<incident_id> Use GET for fetching a single record
type is either intervention or red-flag
#### Any background context you want to provide?
The tests written for getting a single record should pass on this code.
#### What are the relevant pivotal tracker stories?
#162411163
#### Questions:
Any feedback to improve on? Please advise.