### PR TITLE
#162412265 add delete incident by ID endpoint

### DIFF
--- a/app/api/v2/views/incidents_view.py
+++ b/app/api/v2/views/incidents_view.py
@@ -98,3 +98,15 @@ class OneIntervention(Resource, Incidents):
                 }, 400
 
         return self.incidents.get_one_incident(type, incident_id)
+
+    def delete(self, type, incident_id):
+        """deletes existing intervention record"""
+
+        if incident_id.isdigit() is False:
+            return {
+                "status": 400,
+                'message': type + ' ID {} is invalid'.format(incident_id)
+                }, 400
+
+        user = get_jwt_identity()
+        return self.incidents.delete_intervention(type, incident_id, user)

--- a/tests/v2/test_incidents.py
+++ b/tests/v2/test_incidents.py
@@ -138,7 +138,7 @@ class IncidentsTests(unittest.TestCase):
         self.assertEqual(response.status_code, 404)
         result = json.loads(response.data)
         self.assertEqual(result['message'],
-                         'No Intervention records available')
+                         'No intervention records available')
 
     def test_gets_a_single(self):
         """test that can fetch a single the incident record"""


### PR DESCRIPTION
#### What does this PR do?
Add the endpoint for deleting a single intervention record or red flag
#### Description of Task to be completed?
Create an endpoint for deleting a single incident record based on the type and the ID
#### How should this be manually tested?

- clone the repo
- git clone https://github.com/Benkimeric/iReporter-API.git
- create and activate the virtual environment
- virtualenv <environment name>
- $source <env name>/bin/activate (in bash)
- install project dependencies by:
    $pip install -r requirements.txt
- python  run.py or flask run
- Use postman to test the endpoint at this route `api/v2/<type>s/`<incident_id> Use DELETE to delete a single record
`type` is either intervention or red-flag
#### Any background context you want to provide?
The tests written for deleting a single record should pass on this code.
#### What are the relevant pivotal tracker stories?
#162412265
#### Questions:
Any feedback to improve on? Please advise.