### PR TITLE
#162412097 edit incident record comment by type and ID

### DIFF
--- a/app/api/v2/routes2.py
+++ b/app/api/v2/routes2.py
@@ -14,3 +14,4 @@ api.add_resource(OneUser, 'auth/login')
 
 api.add_resource(IncidentViews, '<type>s')
 api.add_resource(OneIntervention, '<type>s/<incident_id>')
+api.add_resource(EditComment, '<type>s/<incident_id>/comment')

--- a/app/api/v2/views/incidents_view.py
+++ b/app/api/v2/views/incidents_view.py
@@ -110,3 +110,50 @@ class OneIntervention(Resource, Incidents):
 
         user = get_jwt_identity()
         return self.incidents.delete_intervention(type, incident_id, user)
+
+parser_patch_c = reqparse.RequestParser(bundle_errors=True)
+parser_patch_c.add_argument(
+        'comment', type=str,
+        required=True,
+        help="Comment cannot be left blank"
+    )
+
+
+class EditComment(Resource, Incidents):
+    """contains method to edit an incident record"""
+
+    def __init__(self):
+        """Initialises the editcomment class"""
+
+        self.incidents = Incidents()
+
+    def patch(self, type, incident_id):
+        """updates incident record comment"""
+
+        if incident_id.isdigit() is False:
+            return {
+                "status": 400,
+                'message': type + ' ID {} is invalid'.format(incident_id)
+                }, 400
+
+        args = parser_patch_c.parse_args()
+        data = request.get_json()
+
+        comment = data['comment']
+        user = get_jwt_identity()
+
+        if not re.match(r"^[a-zA-Z0-9 \"!?.,-]+$", data['comment']):
+            return {
+                "message": "A comment cannot contain special characters e.g $"
+                }, 400
+
+        return self.incidents.update_intervention(
+            type, incident_id, user, comment)
+
+
+parser_patch_l = reqparse.RequestParser(bundle_errors=True)
+parser_patch_l.add_argument(
+        'location', type=str,
+        required=True,
+        help="Location cannot be left blank"
+    )


### PR DESCRIPTION
#### What does this PR do?
Add the endpoint for editing a single intervention record or red flag
#### Description of Task to be completed?
Create an endpoint for editing a single incident record based on the type.
#### How should this be manually tested?

- clone the repo
- git clone https://github.com/Benkimeric/iReporter-API.git
- create and activate the virtual environment
- virtualenv <environment name>
- $source <env name>/bin/activate (in bash)
- install project dependencies by:
    $pip install -r requirements.txt
- python  run.py or flask run
- Use postman to test the endpoint at this route `api/v2/<type>s/`<incident_id>/comment Use PATCH to edit record
type is either intervention or red-flag
#### Any background context you want to provide?
The tests written for editing a single record comment should pass on this code.
#### What are the relevant pivotal tracker stories?
#162412097
#### Questions:
Any feedback to improve on? Please advise.