### PR TITLE
#162609782  Allow app to return incident object on patch location and add more validation

### DIFF
--- a/app/api/v2/models/incidents_model.py
+++ b/app/api/v2/models/incidents_model.py
@@ -219,9 +219,22 @@ class Incidents():
             sql_update = update_query
             cur.execute(sql_update, (comment, type, incident_id,))
             conn.commit()
+            # updated record
+            sql = self.incident_fetch()
+            cur.execute(sql, (type, incident_id,))
+            updated_data = cur.fetchone()
+
+            incident_dict = {
+                "created by": str(updated_data[2]),
+                "type": updated_data[3],
+                "location": updated_data[4],
+                "status": updated_data[5],
+                "comment": updated_data[6]
+            }
             return {
                 "id": incident_id,
-                "message": "Updated " + type + " records comment"
+                "message": "Updated " + type + " records comment",
+                "data": incident_dict
             }, 200
         except Exception as error:
             print(error)
@@ -273,9 +286,22 @@ class Incidents():
                             incident_id = %s;"
             cur.execute(sql_update, (location, type, incident_id,))
             conn.commit()
+            # updated record
+            sql = self.incident_fetch()
+            cur.execute(sql, (type, incident_id,))
+            updated_data = cur.fetchone()
+
+            incident_dict = {
+                "created by": str(updated_data[2]),
+                "type": updated_data[3],
+                "location": updated_data[4],
+                "status": updated_data[5],
+                "comment": updated_data[6]
+            }
             return {
                 "id": incident_id,
-                'message': 'Updated ' + type + ' records location'
+                'message': 'Updated ' + type + ' records location',
+                "data": incident_dict
             }
         except Exception as error:
             print(error)

--- a/app/api/v2/views/incidents_view.py
+++ b/app/api/v2/views/incidents_view.py
@@ -45,9 +45,11 @@ class IncidentViews(Resource, Incidents):
 
         type = data['record_type']
 
-        if not re.match(r"^[a-zA-Z0-9 \"!?.,-]+$", data['comment']):
+        if not re.match(r"^[a-zA-Z0-9 \"!?.,-]+$", data['comment']
+                        ) or data['comment'].isspace():
             return {
-                "message": "A comment cannot contain special characters e.g $"
+                "message": "A comment cannot contain special characters e.g $ "
+                           "or empty space"
                 }, 400
 
         if data['record_type'] not in map(str.lower, types_or_record):
@@ -57,7 +59,7 @@ class IncidentViews(Resource, Incidents):
                 }, 400
 
         if not re.match(
-                r"^([-+]?\d{1,2}([.]\d+)?),\s*([-+]?\d{1,3}([.]\d+)?)$",
+                r"^[-+]?([1-8]?\d(\.\d+)?|90(\.0+)?),\s*[-+]?(180(\.0+)?|((1[0-7]\d)|([1-9]?\d))(\.\d+)?)$",
                 data['location']
                 ):
             return {
@@ -145,9 +147,11 @@ class EditComment(Resource, Incidents):
         comment = data['comment']
         user = get_jwt_identity()
 
-        if not re.match(r"^[a-zA-Z0-9 \"!?.,-]+$", data['comment']):
+        if not re.match(r"^[a-zA-Z0-9 \"!?.,-]+$", data['comment']
+                        ) or data['comment'].isspace():
             return {
-                "message": "A comment cannot contain special characters e.g $"
+                "message": "A comment cannot contain special characters e.g $ "
+                           "or empty space"
                 }, 400
 
         return self.incidents.update_intervention(
@@ -187,7 +191,7 @@ class EditLocation(Resource, Incidents):
         user = get_jwt_identity()
 
         if not re.match(
-                r"^([-+]?\d{1,2}([.]\d+)?),\s*([-+]?\d{1,3}([.]\d+)?)$",
+                r"^[-+]?([1-8]?\d(\.\d+)?|90(\.0+)?),\s*[-+]?(180(\.0+)?|((1[0-7]\d)|([1-9]?\d))(\.\d+)?)$",
                 location
                 ):
             return {

--- a/tests/v2/incidents_data.py
+++ b/tests/v2/incidents_data.py
@@ -78,3 +78,7 @@ invalid_location_data = {
 admin_status_change = {
     "status": "resolved"
 }
+
+invalid_status = {
+    "status": "simply invalid"
+}


### PR DESCRIPTION
#### What does this PR do?
- Filter empty spaces on incidents' comments
- Added more tests for incidents admin roles
#### Description of Task to be completed?
- Filter empty space on incidents' comments
- Added more tests for incidents admin roles
#### How should this be manually tested?

- clone the repo
- git clone https://github.com/Benkimeric/iReporter-API.git
- create and activate the virtual environment
- virtualenv <environment name>
- $source <env name>/bin/activate (in bash)
- install project dependencies by:
    $pip install -r requirements.txt
- python  run.py or flask run
- Use postman to test any routes as in the readme file
#### What are the relevant pivotal tracker stories?
#162609782
#### Questions:
Any feedback to improve on? Please advise.